### PR TITLE
Refactor storage with unified provider and broadcast sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { BlockerProvider } from './context/BlockerContext';
-import { StandardBlocksProvider } from './context/StandardBlocksContext';
+import { StorageProvider } from './context/StorageProvider';
 import Layout from './components/Layout';
 import BlockerDashboard from './components/BlockerDashboard';
 import HistoryPage from './components/HistoryPage';
@@ -10,17 +9,15 @@ import RequiredBlocksPage from './components/RequiredBlocksPage';
 function App() {
   return (
     <BrowserRouter>
-      <BlockerProvider>
-        <StandardBlocksProvider>
-          <Layout>
-            <Routes>
-              <Route path="/" element={<BlockerDashboard />} />
-              <Route path="/history" element={<HistoryPage />} />
-              <Route path="/required" element={<RequiredBlocksPage />} />
-            </Routes>
-          </Layout>
-        </StandardBlocksProvider>
-      </BlockerProvider>
+      <StorageProvider>
+        <Layout>
+          <Routes>
+            <Route path="/" element={<BlockerDashboard />} />
+            <Route path="/history" element={<HistoryPage />} />
+            <Route path="/required" element={<RequiredBlocksPage />} />
+          </Routes>
+        </Layout>
+      </StorageProvider>
     </BrowserRouter>
   );
 }

--- a/src/components/AddBlockForm.tsx
+++ b/src/components/AddBlockForm.tsx
@@ -249,7 +249,8 @@ const AddBlockForm: React.FC = () => {
         name: blockName.trim(),
         startTime: startTime,
         endTime: endTime,
-        notes: notes.trim()
+        notes: notes.trim(),
+        lastModified: new Date().toISOString()
       });
       
       // Save as standard block if checkbox is checked

--- a/src/components/BlockActions.tsx
+++ b/src/components/BlockActions.tsx
@@ -80,7 +80,8 @@ export const BlockActions: React.FC<BlockActionsProps> = ({
       name: formData.name.trim(),
       startTime: start,
       endTime: end,
-      notes: formData.notes.trim()
+      notes: formData.notes.trim(),
+      lastModified: new Date().toISOString()
     });
 
     setIsEditing(false);

--- a/src/components/ExportImportButtons.tsx
+++ b/src/components/ExportImportButtons.tsx
@@ -1,0 +1,46 @@
+import React, { ChangeEvent } from 'react';
+import { storageService } from '../utils/storageService';
+
+const ExportImportButtons: React.FC = () => {
+  const handleExport = () => {
+    const data = JSON.stringify({ blocks: storageService.getBlocks(), standardBlocks: storageService.getStandardBlocks() }, null, 2);
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'blocker-export.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async () => {
+      try {
+        const text = reader.result as string;
+        const parsed = JSON.parse(text);
+        if (parsed.blocks && parsed.standardBlocks) {
+          storageService.setBlocks(parsed.blocks);
+          storageService.setStandardBlocks(parsed.standardBlocks);
+        }
+      } catch {
+        console.error('Invalid import data');
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="flex gap-2">
+      <button onClick={handleExport} className="px-2 py-1 text-xs text-blue-600 underline">Export</button>
+      <label className="px-2 py-1 text-xs text-blue-600 underline cursor-pointer">
+        Import
+        <input type="file" accept="application/json" onChange={handleImport} className="hidden" />
+      </label>
+    </div>
+  );
+};
+
+export default ExportImportButtons;

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Clock, History, Star } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useStandardBlocks } from '../context/StandardBlocksContext';
 import { useBlocker } from '../context/BlockerContext';
-import { storageService } from '../utils/storageService';
+import { useStorage } from '../context/StorageProvider';
+import ExportImportButtons from './ExportImportButtons';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -18,26 +19,10 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   
   const { getRequiredBlocks, isLoading: standardBlocksLoading } = useStandardBlocks();
   const { blocks, currentTime, isLoading: blocksLoading } = useBlocker();
-  const [fileName, setFileName] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-
-  useEffect(() => {
-    storageService.getInitPromise().then(() => {
-      setFileName(storageService.getFileName());
-    });
-    const fileCb = (n: string | null) => setFileName(n);
-    const saveCb = (s: boolean) => setSaving(s);
-    storageService.subscribeFile(fileCb);
-    storageService.subscribeSaving(saveCb);
-    return () => {
-      storageService.unsubscribeFile(fileCb);
-      storageService.unsubscribeSaving(saveCb);
-    };
-  }, []);
+  const { fileName, saving, changeFile, mode } = useStorage();
 
   const changeLocation = async () => {
-    await storageService.changeFile();
-    setFileName(storageService.getFileName());
+    await changeFile();
   };
   
   // Get active block names for required blocks check
@@ -116,9 +101,11 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   <span className="mr-1">📁</span>{fileName || 'none'}
                   {saving && <span className="ml-2 text-xs text-gray-500">Saving...</span>}
                 </span>
+                <span className="text-xs text-gray-500">({mode})</span>
                 <button onClick={changeLocation} className="underline text-blue-600 text-xs">
                   Change Location
                 </button>
+                <ExportImportButtons />
               </div>
             </div>
           </div>

--- a/src/context/NotificationContext.tsx
+++ b/src/context/NotificationContext.tsx
@@ -1,0 +1,49 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export interface Notification {
+  id: number;
+  message: string;
+  type?: 'info' | 'warning' | 'error';
+}
+
+interface NotificationContextValue {
+  notify: (message: string, type?: 'info' | 'warning' | 'error') => void;
+}
+
+const NotificationContext = createContext<NotificationContextValue | undefined>(undefined);
+
+export const useNotifications = () => {
+  const ctx = useContext(NotificationContext);
+  if (!ctx) throw new Error('useNotifications must be used within NotificationProvider');
+  return ctx;
+};
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notifs, setNotifs] = useState<Notification[]>([]);
+
+  const remove = (id: number) => setNotifs(n => n.filter(nf => nf.id !== id));
+
+  const notify = (message: string, type: 'info' | 'warning' | 'error' = 'info') => {
+    const id = Date.now();
+    setNotifs(n => [...n, { id, message, type }]);
+    setTimeout(() => remove(id), 4000);
+  };
+
+  return (
+    <NotificationContext.Provider value={{ notify }}>
+      {children}
+      <div className="fixed top-2 right-2 space-y-2 z-50">
+        {notifs.map(n => (
+          <div
+            key={n.id}
+            className={`px-3 py-2 rounded shadow text-white ${
+              n.type === 'error' ? 'bg-red-600' : n.type === 'warning' ? 'bg-yellow-600' : 'bg-blue-600'
+            }`}
+          >
+            {n.message}
+          </div>
+        ))}
+      </div>
+    </NotificationContext.Provider>
+  );
+};

--- a/src/context/StandardBlocksContext.tsx
+++ b/src/context/StandardBlocksContext.tsx
@@ -31,32 +31,20 @@ export const StandardBlocksProvider: React.FC<{ children: React.ReactNode }> = (
   
   useEffect(() => {
     let cleanup: (() => void) | undefined;
-    
-    const initializeStorage = async () => {
-      try {
-        setIsLoading(true);
-        await storageService.init();
+
+    storageService.getInitPromise().then(() => {
+      fromFile.current = true;
+      setStandardBlocks(storageService.getStandardBlocks());
+      setIsInitialized(true);
+      setIsLoading(false);
+
+      const cb = (b: StandardBlock[]) => {
         fromFile.current = true;
-        setStandardBlocks(storageService.getStandardBlocks());
-        setIsInitialized(true);
-
-        const cb = (b: StandardBlock[]) => {
-          fromFile.current = true;
-          setStandardBlocks(b);
-        };
-        storageService.subscribeStandard(cb);
-        cleanup = () => storageService.unsubscribeStandard(cb);
-      } catch (error) {
-        console.error('Failed to initialize storage:', error);
-        // Even if initialization fails, we should still set up with empty state
-        setStandardBlocks([]);
-        setIsInitialized(true);
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    initializeStorage();
+        setStandardBlocks(b);
+      };
+      storageService.subscribeStandard(cb);
+      cleanup = () => storageService.unsubscribeStandard(cb);
+    });
 
     return () => {
       if (cleanup) cleanup();

--- a/src/context/StorageProvider.tsx
+++ b/src/context/StorageProvider.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { storageService } from '../utils/storageService';
+import { BlockerProvider } from './BlockerContext';
+import { StandardBlocksProvider } from './StandardBlocksContext';
+import { NotificationProvider, useNotifications } from './NotificationContext';
+
+interface StorageStatus {
+  fileName: string | null;
+  saving: boolean;
+  mode: 'file' | 'localStorage' | 'memory';
+  changeFile: () => Promise<void>;
+}
+
+const StorageContext = React.createContext<StorageStatus | undefined>(undefined);
+
+export const useStorage = () => {
+  const ctx = React.useContext(StorageContext);
+  if (!ctx) throw new Error('useStorage must be used within StorageProvider');
+  return ctx;
+};
+
+const InnerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { notify } = useNotifications();
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [mode, setMode] = useState<'file' | 'localStorage' | 'memory'>('memory');
+
+  useEffect(() => {
+    storageService.init().then(() => {
+      setFileName(storageService.getFileName());
+      setMode(storageService.getMode());
+    });
+    const fileCb = (n: string | null) => setFileName(n);
+    const saveCb = (s: boolean) => setSaving(s);
+    const modeCb = () => setMode(storageService.getMode());
+    storageService.subscribeFile(fileCb);
+    storageService.subscribeSaving(saveCb);
+    storageService.subscribeMode(modeCb);
+    return () => {
+      storageService.unsubscribeFile(fileCb);
+      storageService.unsubscribeSaving(saveCb);
+      storageService.unsubscribeMode(modeCb);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (mode === 'memory') {
+      notify('Running without persistent storage', 'warning');
+    }
+  }, [mode, notify]);
+
+  const changeFile = async () => {
+    await storageService.changeFile();
+    setFileName(storageService.getFileName());
+    setMode(storageService.getMode());
+  };
+
+  return (
+    <StorageContext.Provider value={{ fileName, saving, mode, changeFile }}>
+      <BlockerProvider>
+        <StandardBlocksProvider>{children}</StandardBlocksProvider>
+      </BlockerProvider>
+    </StorageContext.Provider>
+  );
+};
+
+export const StorageProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <NotificationProvider>
+    <InnerProvider>{children}</InnerProvider>
+  </NotificationProvider>
+);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface Block {
   startTime: Date;
   endTime: Date;
   notes?: string;
+  lastModified?: string;
 }
 
 export interface StandardBlock {

--- a/src/utils/storageService.test.ts
+++ b/src/utils/storageService.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { StorageService } from './storageService';
+import { Block } from '../types';
+
+describe('mergeBlocks', () => {
+  it('uses most recent block when ids clash', () => {
+    const s = new StorageService();
+    const now = new Date().toISOString();
+    const older = new Date(Date.now() - 1000).toISOString();
+    const external: Block[] = [{ id: 1, name: 'a', startTime: new Date(), endTime: new Date(), lastModified: older }];
+    const local: Block[] = [{ id: 1, name: 'b', startTime: new Date(), endTime: new Date(), lastModified: now }];
+    // @ts-ignore access private
+    const merged = s['mergeBlocks'](external, local);
+    expect(merged[0].name).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary
- centralize data handling with a new `StorageProvider`
- show notifications through `NotificationProvider`
- add export/import controls in the layout
- track `lastModified` on blocks for merge conflict resolution
- broadcast `dataUpdated` on writes for real‑time sync
- remove polling and update contexts to rely on provider
- add tests for merge behaviour

## Testing
- `npm test`
- `npm run lint`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_684f4da72fcc8324ba48b4b2abd7a259