### PR TITLE
Improve storage sync

### DIFF
--- a/src/components/BlockerDashboard.tsx
+++ b/src/components/BlockerDashboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useBlocker } from '../context/BlockerContext';
+import { useStandardBlocks } from '../context/StandardBlocksContext';
 import AddBlockForm from './AddBlockForm';
 import ActiveBlocksList from './ActiveBlocksList';
 import UpcomingBlocksList from './UpcomingBlocksList';
@@ -8,9 +9,10 @@ import { Loader2 } from 'lucide-react';
 
 const BlockerDashboard: React.FC = () => {
   const { blocks, currentTime, isLoading } = useBlocker();
+  const { isLoading: standardLoading } = useStandardBlocks();
   
   // Show loading state while storage is initializing
-  if (isLoading) {
+  if (isLoading || standardLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="text-center">


### PR DESCRIPTION
## Summary
- refactor StandardBlocksContext to rely on storageService as single source of truth
- refactor BlockerContext similarly
- wait for standard block load when showing dashboard

## Testing
- `npm test --silent` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_6851fc303634832497def0a1dd8be41b